### PR TITLE
-fix synchronous for variable intervals in cpp-runtime

### DIFF
--- a/Compiler/SimCode/SimCode.mo
+++ b/Compiler/SimCode/SimCode.mo
@@ -143,6 +143,7 @@ end ClockedPartition;
 public uniontype SubPartition
   record SUBPARTITION
     list<tuple<SimCodeVar.SimVar, Boolean /*previous*/>> vars;
+    list<SimEqSystem> previousAssignments;  //equations to assign the $CLKPRE_* variables
     list<SimEqSystem> equations;
     list<SimEqSystem> removedEquations;
     BackendDAE.SubClock subClock;

--- a/Compiler/SimCode/SimCodeUtil.mo
+++ b/Compiler/SimCode/SimCodeUtil.mo
@@ -623,6 +623,7 @@ algorithm
 
     prevClockedVars := {};
     isPrevVar := arrayCreate(BackendVariable.varsSize(syst.orderedVars), false);
+    preEquations := {};
     for cr in subPartition.prevVars loop
       (_, varIxs) := BackendVariable.getVar(cr, syst.orderedVars);
       for i in varIxs loop
@@ -639,13 +640,13 @@ algorithm
         simVar.name := ComponentReference.crefPrefixPrevious(cr);
         clockedVars := simVar::clockedVars;
         simEq := SimCode.SES_SIMPLE_ASSIGN(ouniqueEqIndex, simVar.name, DAE.CREF(cr, simVar.type_), DAE.emptyElementSource);
-        equations := simEq::equations;
+        preEquations := simEq::preEquations;
         ouniqueEqIndex := ouniqueEqIndex + 1;
       end if;
     end for;
 
     //otempvars := listAppend(clockedVars, otempvars);
-    simSubPartition := SimCode.SUBPARTITION(prevClockedVars, equations, removedEquations, subPartition.clock, subPartition.holdEvents);
+    simSubPartition := SimCode.SUBPARTITION(prevClockedVars, preEquations, equations, removedEquations, subPartition.clock, subPartition.holdEvents);
 
     assert(isNone(simSubPartitions[subPartIdx]), "SimCodeUtil.translateClockedEquations failed");
     arrayUpdate(simSubPartitions, subPartIdx, SOME(simSubPartition));

--- a/Compiler/Template/CodegenC.tpl
+++ b/Compiler/Template/CodegenC.tpl
@@ -351,8 +351,8 @@ template functionSystemsSynchronous(list<SubPartition> subPartitions, String mod
 ::=
   let systs = subPartitions |> subPartition hasindex i =>
     match subPartition
-      case SUBPARTITION(__) then
-        functionEquationsSynchronous(i, vars, listAppend(equations, removedEquations), modelNamePrefix)
+      case SUBPARTITION(equations=equations, previousAssignments=preveequations) then
+        functionEquationsSynchronous(i, vars, listAppend(listAppend(previousAssignments,equations), removedEquations), modelNamePrefix)
     ; separator = "\n"
   let cases = subPartitions |> subPartition hasindex i =>
     let name = 'functionEquationsSynchronous_system<%i%>'

--- a/Compiler/Template/SimCodeTV.mo
+++ b/Compiler/Template/SimCodeTV.mo
@@ -333,6 +333,7 @@ package SimCode
   uniontype SubPartition
     record SUBPARTITION
       list<tuple<SimCodeVar.SimVar, Boolean>> vars;
+      list<SimEqSystem> previousAssignments;
       list<SimEqSystem> equations;
       list<SimEqSystem> removedEquations;
       BackendDAE.SubClock subClock;


### PR DESCRIPTION
I separated the clocked partition equations into: clocked equations and assignments for the previous(var).
The workflow during a tick is now as follows:
1. evaluate partition equations (no previous-var assignments)
2. compute next tick-time
3. assign previous-vars
Thats basically everything. The test are ok despite the last value is wrong because its always the left limit of the last value. 